### PR TITLE
Investigate and fix issues with HEAD ref not found bug

### DIFF
--- a/.changeset/shaggy-eels-promise.md
+++ b/.changeset/shaggy-eels-promise.md
@@ -1,0 +1,5 @@
+---
+"@s0/ghcommit": patch
+---
+
+Address issue with Ref HEAD not found

--- a/.changeset/shaggy-eels-promise.md
+++ b/.changeset/shaggy-eels-promise.md
@@ -1,5 +1,0 @@
----
-"@s0/ghcommit": patch
----
-
-Address issue with Ref HEAD not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @s0/ghcommit
 
+## 1.2.1
+
+### Patch Changes
+
+- 85ec677: Address issue with Ref HEAD not found
+
 ## 1.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s0/ghcommit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "description": "Directly change files on github using the github API, to support GPG signing",
   "keywords": [

--- a/src/core.ts
+++ b/src/core.ts
@@ -79,10 +79,6 @@ export const commitFilesFromBase64 = async ({
     throw new Error(`Repository ${repositoryNameWithOwner} not found`);
   }
 
-  if (!info.baseRef) {
-    throw new Error(`Ref ${baseRef} not found`);
-  }
-
   const repositoryId = info.id;
   /**
    * The commit oid to base the new commit on.
@@ -97,6 +93,10 @@ export const commitFilesFromBase64 = async ({
   if ("branch" in base && base.branch === branch) {
     log?.debug(`Committing to the same branch as base: ${branch} (${baseOid})`);
     // Get existing branch refId
+
+    if (!info.baseRef) {
+      throw new Error(`Ref ${baseRef} not found`);
+    }
     refId = info.baseRef.id;
   } else {
     // Determine if the branch needs to be created or not

--- a/src/git.ts
+++ b/src/git.ts
@@ -87,6 +87,7 @@ export const commitChangesFromRepo = async ({
   return commitFilesFromBuffers({
     ...otherArgs,
     fileChanges,
+    log,
     base: {
       commit: oid,
     },


### PR DESCRIPTION
Changes to the GitHub GraphQL API mean that resolving references with `HEAD` no longer work.

However, we don't need to actually do this when providing a commit SHA as a base, so we can move the error check to only when we need this information when committing to the same branch as the base.