### PR TITLE
Remove unused `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-provenance=true
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
It seems to me this is now redundant since the recent publish-related changes. I've missed the fact this file existed in my previous PRs