### PR TITLE
Skip integration tests on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Integration tests push to the repo, which requires a token with write
+    # access. Fork PRs only get a read-only GITHUB_TOKEN, so skip them here
+    # and rely on merge_group to gate the merge.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write # integration tests create and push temporary branches
     steps:


### PR DESCRIPTION
Integration tests `git push` to the repo. Fork PRs only get a read-only `GITHUB_TOKEN`, so the `test` job always 403s. This PR skips the `test` job when the PR comes from a fork.

If my understanding is correct, coverage is unchanged because `merge_group` still runs the full suite before merge:

```yaml
name: CI

on:
  pull_request:
  merge_group:
    branches:
      - main
```

The resulting flow for a fork contribution:

1. A PR from their fork, `pull_request` fires. Code is untrusted, `GITHUB_TOKEN` is read-only, `CI / Test` is skipped.
2. Maintainer reviews, approves, and clicks **Add to merge queue** button.
3. `merge_group` fires in the base repo context with a writable `GITHUB_TOKEN`, running the full suite against the now-trusted code.
   - If all jobs in `merge_group` pass, the commit lands on `main`.  
   - If `CI / Test` in `merge_group` fails, the required check `CI / CI OK` will also fail, and the commit won't land.