### PR TITLE
Make git unit test not flaky

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -149,8 +149,8 @@ export async function getFileChanges(
     },
   });
 
-  additions.sort((a, b) => a.path.localeCompare(b.path));
-  deletions.sort((a, b) => a.path.localeCompare(b.path));
+  additions.sort((a, b) => (a.path > b.path ? 1 : -1));
+  deletions.sort((a, b) => (a.path > b.path ? 1 : -1));
 
   return { additions, deletions };
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -149,5 +149,8 @@ export async function getFileChanges(
     },
   });
 
+  additions.sort((a, b) => a.path.localeCompare(b.path));
+  deletions.sort((a, b) => a.path.localeCompare(b.path));
+
   return { additions, deletions };
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -45,15 +45,16 @@ export const commitChangesFromRepo = async ({
 
   return await commitFilesFromBase64({
     ...otherArgs,
+    base: base ?? { commit: oid },
     fileChanges: await getFileChanges(
       workingDirectory,
       repoRoot,
       oid,
       filterFiles,
     ),
-    base: {
-      commit: oid,
-    },
+    // base: {
+    //   commit: oid,
+    // },
   });
 };
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -45,16 +45,15 @@ export const commitChangesFromRepo = async ({
 
   return await commitFilesFromBase64({
     ...otherArgs,
-    base: base ?? { commit: oid },
     fileChanges: await getFileChanges(
       workingDirectory,
       repoRoot,
       oid,
       filterFiles,
     ),
-    // base: {
-    //   commit: oid,
-    // },
+    base: {
+      commit: oid,
+    },
   });
 };
 

--- a/tests/integration/node.test.ts
+++ b/tests/integration/node.test.ts
@@ -254,7 +254,7 @@ describe("node", () => {
         ...REPO,
         branch,
         base: {
-          tag: "v2.1.0",
+          tag: "v1.4.0",
         },
         ...BASIC_FILE_CONTENTS,
       });

--- a/tests/integration/node.test.ts
+++ b/tests/integration/node.test.ts
@@ -254,7 +254,7 @@ describe("node", () => {
         ...REPO,
         branch,
         base: {
-          tag: "v1.4.0",
+          tag: "v2.1.0",
         },
         ...BASIC_FILE_CONTENTS,
       });


### PR DESCRIPTION
I saw in CI this part https://github.com/changesets/ghcommit/blob/506855ab7eeb83b34bea17b66a6094845b4c2679/tests/git.test.ts#L49-L62 could fail because the order may be non-deterministic. (c.txt before a.txt)

Added a sort to fix this. Shouldn't affect people in practice but I think it's good to sort in the implementation side so that the requests we send are also deterministic.