### PR TITLE
Rename as sha for tests

### DIFF
--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -12,8 +12,8 @@ import {
   expectBranchHasFile,
   expectBranchHasTree,
   expectBranchNotHaveFile,
-  expectParentHasOid,
-  getOid,
+  expectParentHasSha,
+  getSha,
   getTempBranch,
   octokit,
   owner,
@@ -26,7 +26,7 @@ import {
 
 const BASIC_FILE_CHANGES_PATH = "foo.txt";
 const BASIC_FILE_BUFFER = Buffer.alloc(1024, "Hello, world!");
-const BASIC_FILE_CHANGES_OID = getOid(BASIC_FILE_BUFFER);
+const BASIC_FILE_CHANGES_SHA = getSha(BASIC_FILE_BUFFER);
 const BASIC_FILE_CONTENTS = BASIC_FILE_BUFFER.toString("base64");
 const BASIC_FILE_CHANGES = {
   additions: [
@@ -95,13 +95,13 @@ describe("commitFilesFromBase64", () => {
       .trim()
       .split("\n")
       .map((line) => {
-        const [oid, tree] = line.split(" ");
-        return { oid, tree };
+        const [commitSha, treeSha] = line.split(" ");
+        return { commitSha, treeSha };
       });
 
-    testTargetCommit = logs[1]?.oid ?? "N/A";
-    testTargetCommit2 = logs[0]?.oid ?? "N/A";
-    testTargetTree2 = logs[0]?.tree ?? "N/A";
+    testTargetCommit = logs[1]?.commitSha ?? "N/A";
+    testTargetCommit2 = logs[0]?.commitSha ?? "N/A";
+    testTargetTree2 = logs[0]?.treeSha ?? "N/A";
   });
 
   it("can commit files", async () => {
@@ -140,17 +140,17 @@ describe("commitFilesFromBase64", () => {
     await expectBranchHasFile({
       branch,
       filePath: "new-file.txt",
-      fileOid: getOid(buffers.newFile),
+      fileSha: getSha(buffers.newFile),
     });
     await expectBranchHasFile({
       branch,
       filePath: "README.md",
-      fileOid: getOid(buffers.updated),
+      fileSha: getSha(buffers.updated),
     });
     await expectBranchHasFile({
       branch,
       filePath: "tests/file.txt",
-      fileOid: getOid(buffers.nested),
+      fileSha: getSha(buffers.nested),
     });
     await expectBranchNotHaveFile({ branch, filePath: "CHANGELOG.md" });
   });
@@ -181,7 +181,7 @@ describe("commitFilesFromBase64", () => {
       await expectBranchHasFile({
         branch,
         filePath: `${sizeName}.txt`,
-        fileOid: getOid(buffer),
+        fileSha: getSha(buffer),
       });
     }
   });
@@ -204,7 +204,7 @@ describe("commitFilesFromBase64", () => {
     await expectBranchHasFile({
       branch,
       filePath: BASIC_FILE_CHANGES_PATH,
-      fileOid: BASIC_FILE_CHANGES_OID,
+      fileSha: BASIC_FILE_CHANGES_SHA,
     });
   });
 
@@ -229,7 +229,7 @@ describe("commitFilesFromBase64", () => {
     await expectBranchHasFile({
       branch,
       filePath: BASIC_FILE_CHANGES_PATH,
-      fileOid: BASIC_FILE_CHANGES_OID,
+      fileSha: BASIC_FILE_CHANGES_SHA,
     });
   });
 
@@ -250,7 +250,7 @@ describe("commitFilesFromBase64", () => {
     await expectBranchHasFile({
       branch,
       filePath: BASIC_FILE_CHANGES_PATH,
-      fileOid: BASIC_FILE_CHANGES_OID,
+      fileSha: BASIC_FILE_CHANGES_SHA,
     });
   });
 
@@ -281,10 +281,10 @@ describe("commitFilesFromBase64", () => {
       await expectBranchHasFile({
         branch,
         filePath: BASIC_FILE_CHANGES_PATH,
-        fileOid: BASIC_FILE_CHANGES_OID,
+        fileSha: BASIC_FILE_CHANGES_SHA,
       });
 
-      await expectParentHasOid({ branch, oid: testTargetCommit });
+      await expectParentHasSha({ branch, sha: testTargetCommit });
       await expectBranchDoesNotExist(internalTempBranch);
     });
 
@@ -321,10 +321,10 @@ describe("commitFilesFromBase64", () => {
       await expectBranchHasFile({
         branch,
         filePath: BASIC_FILE_CHANGES_PATH,
-        fileOid: BASIC_FILE_CHANGES_OID,
+        fileSha: BASIC_FILE_CHANGES_SHA,
       });
 
-      await expectParentHasOid({ branch, oid: testTargetCommit });
+      await expectParentHasSha({ branch, sha: testTargetCommit });
       await expectBranchDoesNotExist(internalTempBranch);
     });
 
@@ -354,7 +354,7 @@ describe("commitFilesFromBase64", () => {
 
       await expectBranchHasTree({
         branch,
-        treeOid: testTargetTree2,
+        treeSha: testTargetTree2,
       });
     });
 
@@ -383,7 +383,7 @@ describe("commitFilesFromBase64", () => {
       await expectBranchHasFile({
         branch,
         filePath: BASIC_FILE_CHANGES_PATH,
-        fileOid: BASIC_FILE_CHANGES_OID,
+        fileSha: BASIC_FILE_CHANGES_SHA,
       });
     });
 
@@ -412,7 +412,7 @@ describe("commitFilesFromBase64", () => {
       await expectBranchHasFile({
         branch,
         filePath: BASIC_FILE_CHANGES_PATH,
-        fileOid: BASIC_FILE_CHANGES_OID,
+        fileSha: BASIC_FILE_CHANGES_SHA,
       });
     });
   });

--- a/tests/integration/utils.ts
+++ b/tests/integration/utils.ts
@@ -35,7 +35,7 @@ export function getTempBranch(name: string) {
 /**
  * Calculate the SHA using git blob hash format
  */
-export function getOid(contents: Buffer): string {
+export function getSha(contents: Buffer): string {
   const header = Buffer.from(`blob ${contents.length}\0`);
   return crypto
     .createHash("sha1")
@@ -48,10 +48,10 @@ export function getOid(contents: Buffer): string {
 
 export async function expectBranchHasTree({
   branch,
-  treeOid,
+  treeSha,
 }: {
   branch: string;
-  treeOid: string;
+  treeSha: string;
 }) {
   const ref = (
     await getRefTreeQuery(octokit, {
@@ -66,17 +66,17 @@ export async function expectBranchHasTree({
     throw new Error("Unexpected missing ref");
   }
 
-  expect(ref.tree.oid).toEqual(treeOid);
+  expect(ref.tree.oid).toEqual(treeSha);
 }
 
 export async function expectBranchHasFile({
   branch,
   filePath,
-  fileOid,
+  fileSha,
 }: {
   branch: string;
   filePath: string;
-  fileOid: string;
+  fileSha: string;
 }) {
   const ref = (
     await getRefTreeQuery(octokit, {
@@ -91,7 +91,7 @@ export async function expectBranchHasFile({
     throw new Error("Unexpected missing ref");
   }
 
-  expect(ref.file?.oid).toEqual(fileOid);
+  expect(ref.file?.oid).toEqual(fileSha);
 }
 
 export async function expectBranchNotHaveFile({
@@ -111,12 +111,12 @@ export async function expectBranchNotHaveFile({
   ).rejects.toThrow("Could not resolve file for path");
 }
 
-export async function expectParentHasOid({
+export async function expectParentHasSha({
   branch,
-  oid,
+  sha,
 }: {
   branch: string;
-  oid: string;
+  sha: string;
 }) {
   const ref = (
     await getRefTreeQuery(octokit, {
@@ -131,7 +131,7 @@ export async function expectParentHasOid({
     throw new Error("Unexpected result");
   }
 
-  expect(ref.parents.nodes?.[0]?.oid).toEqual(oid);
+  expect(ref.parents.nodes?.[0]?.oid).toEqual(sha);
 }
 
 export async function expectBranchDoesNotExist(branch: string) {


### PR DESCRIPTION
This does oid -> sha rename similar to #111 but for the core tests. Separated so slightly easier to review.