### PR TITLE
Refactor internal octokit usage

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -2,6 +2,7 @@ import type { GetRepositoryMetadataQuery } from "./github/graphql/generated/oper
 import {
   createCommitOnBranchQuery,
   getRepositoryMetadata,
+  type Octokit,
 } from "./github/graphql/queries.ts";
 import type { CommitChangesOptions, CommitChangesResult } from "./types.ts";
 import { normalizeCommitMessage, resolveGitRef } from "./utils.ts";
@@ -17,7 +18,7 @@ type CreateCommit = (
  * Works in Node.js and browsers.
  */
 export async function commitChanges({
-  octokit,
+  octokit: partialOctokit,
   owner,
   repo,
   branch,
@@ -26,6 +27,7 @@ export async function commitChanges({
   message,
   fileChanges,
 }: CommitChangesOptions): Promise<CommitChangesResult> {
+  const octokit = partialOctokit as Octokit;
   const baseRef = resolveGitRef(base);
 
   const info = await getRepositoryMetadata(octokit, {
@@ -168,7 +170,10 @@ async function createOrForceUpdateTemporaryBranch({
   repo,
   tempBranch,
   baseSha,
-}: Pick<CommitChangesOptions, "octokit" | "owner" | "repo"> & {
+}: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
   tempBranch: string;
   baseSha: string;
 }) {

--- a/src/github/graphql/queries.ts
+++ b/src/github/graphql/queries.ts
@@ -1,37 +1,17 @@
-// Octokit types are messy. To avoid adding any (peer)dependencies we rely on TS structural typing here
-export type Octokit = {
-  graphql: <T>(
-    query: string,
-    variables?: Record<string, unknown>,
-  ) => Promise<T>;
-  rest: {
-    git: {
-      createRef: (params: {
-        owner: string;
-        repo: string;
-        ref: string;
-        sha: string;
-      }) => Promise<{ data: { node_id?: string } }>;
-      updateRef: (params: {
-        owner: string;
-        repo: string;
-        ref: string;
-        sha: string;
-        force?: boolean;
-      }) => Promise<{ data: { node_id?: string } }>;
-      deleteRef: (params: {
-        owner: string;
-        repo: string;
-        ref: string;
-      }) => Promise<unknown>;
-      getRef?: (params: {
-        owner: string;
-        repo: string;
-        ref: string;
-      }) => Promise<unknown>;
-    };
-  };
-};
+import type { getOctokit } from "@actions/github";
+
+export type Octokit = ReturnType<typeof getOctokit>;
+
+/**
+ * Rough shape of the Octokit instance we need so we don't depend on the full
+ * dependency and types.
+ */
+export interface PartialOctokit {
+  request: unknown;
+  graphql: unknown;
+  rest: unknown;
+  paginate: unknown;
+}
 
 import type {
   CreateCommitOnBranchMutation,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type {
   CommitMessage,
   FileChanges,
 } from "./github/graphql/generated/types.ts";
-import type { Octokit } from "./github/graphql/queries.ts";
+import type { PartialOctokit } from "./github/graphql/queries.ts";
 
 export type GitRef = { branch: string } | { tag: string } | { commit: string };
 
@@ -12,7 +12,7 @@ export interface CommitChangesOptions {
    * from `@octokit/core`, `@octokit/plugin-rest-endpoint-methods`, and
    * `@octokit/plugin-paginate-rest`.
    */
-  octokit: Octokit;
+  octokit: PartialOctokit;
   /**
    * The owner of the repository.
    */

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   clean: !process.argv.includes("--watch"),
   deps: {
     onlyBundle: [], // require explicitly listing inlined dependencies
+    neverBundle: [
+      // Referenced in internal types only and should be treeshaken away, but
+      // we need to specify it here to allow for linking before treeshaking
+      "@actions/github",
+    ],
   },
 
   sourcemap: !isCi,


### PR DESCRIPTION
So that internally we use the complete Octokit types, which allows us to easily use the API later. The stub Octokit type is renamed as `PartialOctokit` with also a simplified shape. I manually tested and it's still possible to detect if `.rest` or `.paginate` is missing in the octokit instance, if they didn't set up, for example.

I decided to not export `PartialOctokit` still as there's not a lot of reason users would need that in practice. It's better to use the type of their own Octokit instance, and then relying on typechecking if it can be passed to our function.